### PR TITLE
Drop support for Ruby 1.9.3, add support for Ruby 2.3.0, 2.4.1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,5 @@
 
 #### Purpose
 
-#### Known Compatablity Issues
+#### Known Compatibility Issues
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
+- 2.4.1
 notifications:
   email:
     recipients:
@@ -27,7 +28,8 @@ deploy:
     tags: true
     repo: sensu-plugins/sensu-plugins-nbzget
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
+    rvm: 2.3.0
+    rvm: 2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
-- Support for Ruby 2.3.0
-- Support for Ruby 2.4.1
+- Add testing for Ruby 2.3.0
+- Add testing for Ruby 2.4.1
 
 ### Breaking Changes
 - Drop support for Ruby 1.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Support for Ruby 2.3.0
+- Support for Ruby 2.4.1
+
+### Breaking Changes
+- Drop support for Ruby 1.9.3
 
 ## [0.0.3] - 2015-07-14
 ### Changed

--- a/Rakefile
+++ b/Rakefile
@@ -6,15 +6,6 @@ require 'rubocop/rake_task'
 require 'yard'
 require 'yard/rake/yardoc_task'
 
-desc 'Don\'t run Rubocop for unsupported versions'
-begin
-  args = if RUBY_VERSION >= '2.0.0'
-           [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
-         else
-           [:spec, :make_bin_executable, :yard]
-         end
-end
-
 YARD::Rake::YardocTask.new do |t|
   OTHER_PATHS = %w().freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
@@ -44,4 +35,4 @@ task :check_binstubs do
   end
 end
 
-task default: args
+task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]

--- a/sensu-plugins-nbzget.gemspec
+++ b/sensu-plugins-nbzget.gemspec
@@ -3,11 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
 
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-nbzget'
-else
-  require_relative 'lib/sensu-plugins-nbzget'
-end
+require_relative 'lib/sensu-plugins-nbzget'
 
 Gem::Specification.new do |s|
   s.authors                = ['Sensu-Plugins and contributors']
@@ -27,7 +23,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
   s.summary                = 'Sensu plugins for nbzget'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsNbzget::Version::VER_STRING


### PR DESCRIPTION
## Pull Request Checklist

sensu-plugins/sensu-plugins-feature-requests#27

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
Add support for Ruby 2.3.0, 2.4.1

#### Known Compatablity Issues
Drop support for Ruby 1.9.3
